### PR TITLE
Fix stunts having "undefined" in them

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -86,7 +86,9 @@ $(function() {
 			if (when === 'TWO') {
 				// when_low = when_low.pop();
 				w1 = random_array_item(when_low);
-				w2 = random_array_item(when_low,w1);
+				do {
+					w2 = random_array_item(when_low);
+				} while (w1 === w2);
 				when = w1 + ", " + w2;
 			}
 


### PR DESCRIPTION
When calling random_array_item with a second
parameter, it shortens the array. Doing this repeatedly
results in an empty array. Selecting a string from this
array results in an undefined value, which gets put in
the generated stunts.